### PR TITLE
レスポンシブ画像のタグをdivからimgに一括置換

### DIFF
--- a/coordinate/index.html
+++ b/coordinate/index.html
@@ -15,6 +15,6 @@ category: '着こなしのご提案'
 
 <section>
     <h2>ばあちゃんの着こなし</h2>
-    <div class="img-sm" data-width="720" data-src="/images/coordinate-baachan-P1090240-P1090319-{width}{pixel_ratio}.JPG" data-alt="七緒" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/coordinate-baachan-P1090240-P1090319-{width}{pixel_ratio}.JPG" data-alt="七緒" data-class="img-responsive img-rounded">
     <p><a href = "http://blog.darumaya-gofuku.jp/search/label/%E3%81%B0%E3%81%82%E3%81%A1%E3%82%83%E3%82%93%E3%81%AE%E7%9D%80%E3%81%93%E3%81%AA%E3%81%97" target = "_blank">だるまやのばあちゃんの着こなしです。</a></p>
 </section>

--- a/coordinate/komon.html
+++ b/coordinate/komon.html
@@ -29,7 +29,7 @@ order: 60
     <div class="row">
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume1-DSC04953-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume1-DSC04953-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>1月は初詣や初窯など、礼装を着る機会が多いですよね。。無地では少しさびしいですし、やはり附下と袋帯をおすすめします。</p>
@@ -38,7 +38,7 @@ order: 60
         </div>
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume2-DSC04944-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume2-DSC04944-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>最近は柄が全体にある華やかな品物より、肩と裾にさりげなく柄があるすっきりした附下が評判良いです。</p>
@@ -47,7 +47,7 @@ order: 60
         </div>
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume3-DSC04967-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume3-DSC04967-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>このきもの、きものが焦げ茶なので、薄い色の帯を合わせがちですが、思い切って濃い色の帯を合わせてみました。</p>
@@ -69,7 +69,7 @@ order: 60
     <div class="row">
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume1-DSC04953-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume1-DSC04953-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>1月は初詣や初窯など、礼装を着る機会が多いですよね。。無地では少しさびしいですし、やはり附下と袋帯をおすすめします。</p>
@@ -78,7 +78,7 @@ order: 60
         </div>
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume2-DSC04944-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume2-DSC04944-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>最近は柄が全体にある華やかな品物より、肩と裾にさりげなく柄があるすっきりした附下が評判良いです。</p>
@@ -87,7 +87,7 @@ order: 60
         </div>
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume3-DSC04967-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume3-DSC04967-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>このきもの、きものが焦げ茶なので、薄い色の帯を合わせがちですが、思い切って濃い色の帯を合わせてみました。</p>

--- a/coordinate/osusume.html
+++ b/coordinate/osusume.html
@@ -17,7 +17,7 @@ order: 10
     <div class="row">
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume1-DSC04953-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume1-DSC04953-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>1月は初詣や初窯など、礼装を着る機会が多いですよね。。無地では少しさびしいですし、やはり附下と袋帯をおすすめします。</p>
@@ -26,7 +26,7 @@ order: 10
         </div>
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume2-DSC04944-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume2-DSC04944-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>最近は柄が全体にある華やかな品物より、肩と裾にさりげなく柄があるすっきりした附下が評判良いです。</p>
@@ -35,7 +35,7 @@ order: 10
         </div>
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume3-DSC04967-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume3-DSC04967-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>このきもの、きものが焦げ茶なので、薄い色の帯を合わせがちですが、思い切って濃い色の帯を合わせてみました。</p>

--- a/coordinate/tsukesage.html
+++ b/coordinate/tsukesage.html
@@ -28,7 +28,7 @@ order: 20
     <div class="row">
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume1-DSC04953-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume1-DSC04953-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>1月は初詣や初窯など、礼装を着る機会が多いですよね。。無地では少しさびしいですし、やはり附下と袋帯をおすすめします。</p>
@@ -37,7 +37,7 @@ order: 20
         </div>
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume2-DSC04944-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume2-DSC04944-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>最近は柄が全体にある華やかな品物より、肩と裾にさりげなく柄があるすっきりした附下が評判良いです。</p>
@@ -46,7 +46,7 @@ order: 20
         </div>
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume3-DSC04967-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume3-DSC04967-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>このきもの、きものが焦げ茶なので、薄い色の帯を合わせがちですが、思い切って濃い色の帯を合わせてみました。</p>
@@ -68,7 +68,7 @@ order: 20
     <div class="row">
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume1-DSC04953-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume1-DSC04953-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>1月は初詣や初窯など、礼装を着る機会が多いですよね。。無地では少しさびしいですし、やはり附下と袋帯をおすすめします。</p>
@@ -77,7 +77,7 @@ order: 20
         </div>
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume2-DSC04944-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume2-DSC04944-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>最近は柄が全体にある華やかな品物より、肩と裾にさりげなく柄があるすっきりした附下が評判良いです。</p>
@@ -86,7 +86,7 @@ order: 20
         </div>
         <div class="col-xs-12 col-sm-6 col-md4">
             <div class="thumbnail">
-                <div class="img-lg" data-src="/images/coordinate-osusume3-DSC04967-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+                <img class="img-lg" data-src="/images/coordinate-osusume3-DSC04967-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
                 <div class="caption">
                     <h3>附下と袋帯</h3>
                     <p>このきもの、きものが焦げ茶なので、薄い色の帯を合わせがちですが、思い切って濃い色の帯を合わせてみました。</p>

--- a/event/araiharitaiken.html
+++ b/event/araiharitaiken.html
@@ -25,10 +25,10 @@ order: 50
 <section>
     <h2>過去の洗い張り体験の様子</h2>
     <p>2012年12月</p>
-    <div class="img-sm" data-width="720" data-src="/images/araiharitaiken-20121202-P1120337-{width}{pixel_ratio}.JPG" data-alt="湘南ジャーナル" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/araiharitaiken-20121202-P1120337-{width}{pixel_ratio}.JPG" data-alt="湘南ジャーナル" data-class="img-responsive img-rounded">
     <br>
     <p>2014年11月</p>
-    <div class="img-sm" data-width="720" data-src="/images/araiharitaiken-20141129-DSC05293-{width}{pixel_ratio}.JPG" data-alt="湘南ジャーナル" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/araiharitaiken-20141129-DSC05293-{width}{pixel_ratio}.JPG" data-alt="湘南ジャーナル" data-class="img-responsive img-rounded">
     <br>
     <p>その他、ブログで洗い張り体験の様子を掲載しています。
     <a href = "http://blog.darumaya-gofuku.jp/search/label/%E6%B4%97%E3%81%84%E5%BC%B5%E3%82%8A%E4%BD%93%E9%A8%93" target = "_blank">洗い張り体験の様子はこちら</a>

--- a/event/index.html
+++ b/event/index.html
@@ -14,7 +14,7 @@ category: '催事のご案内'
 <section>
     <h2>ポストカード</h2>
     <p>感謝祭や展示会など、だるまやの催事の際にポストカードをお送りしています。</p>
-    <div class="img-sm" data-width="720" data-src="/images/newsletter-postcard-DSC05270-{width}{pixel_ratio}.JPG" data-alt="ポストカード" data-class="img-responsive img-rounded"></div><br>
+    <img class="img-sm" data-width="720" data-src="/images/newsletter-postcard-DSC05270-{width}{pixel_ratio}.JPG" data-alt="ポストカード" data-class="img-responsive img-rounded"><br>
     <p>以下のフォームにお名前、内容枠にお客様のご住所とポストカード希望の旨を記入して送信してください。<br>
         なお、メールアドレスもご記入いただくと、メールマガジンも併せて登録いたします。<br>
         ポストカードは店内でもお渡しできますので、遠慮無くお声がけくださいませ。</p>

--- a/event/tenjikai.html
+++ b/event/tenjikai.html
@@ -21,7 +21,7 @@ order: 20
 </section>
 <section>
     <h2>過去のきものと帯展の様子</h2>
-    <div class="img-sm" data-width="720" data-src="/images/tenjikai-sample-DSC02786-{width}{pixel_ratio}.JPG" data-alt="湘南ジャーナル" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/tenjikai-sample-DSC02786-{width}{pixel_ratio}.JPG" data-alt="湘南ジャーナル" data-class="img-responsive img-rounded">
     <p>前回の「きものと帯展」の写真です。<br>
         この写真はほんの一部で、実際はだるまやの2階の3部屋にきものと帯を飾ります！</p>
 </section>

--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@ news:
     <div class="row">
         <div class="col-sm-6">
             <div class="thumbnail">
-                <a href="/revival/" class="img-link"><div class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="きものの再生事例"></div></a>
+                <a href="/revival/" class="img-link"><img class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="きものの再生事例"></a>
                 <div class="caption">
                     <h3>きものの再生事例
                         <small>~無地のきものを染め替える~</small></h3>
@@ -133,7 +133,7 @@ news:
         </div>
         <div class="col-sm-6">
             <div class="thumbnail">
-                <a href="/revival/" class="img-link"><div class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="今月のおすすめ商品"></div></a>
+                <a href="/revival/" class="img-link"><img class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="今月のおすすめ商品"></a>
                 <div class="caption">
                     <h3>今月のおすすめ商品</h3>
                     <p>今月のおすすめ商品は、お遊び長襦袢です。<br>袖からチラッと見えた時に、「え、その長襦袢、可愛い！！」と言われちゃいますよ！他にも振袖から小紋までおすすめ商品を紹介します。</p>

--- a/information/history.html
+++ b/information/history.html
@@ -24,30 +24,30 @@ order: 30
     <h4>3代目　繁太郎</h4>
         <p>店を平塚に移す。<br>
             仕事は変わらず、藍染を中心とした染物業と洗い張りなどを行う。</p>
-        <div class="img-xs" data-width="360" data-src="/images/history-showa7_1-P1060458-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+        <img class="img-xs" data-width="360" data-src="/images/history-showa7_1-P1060458-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
         <br>
-        <div class="img-xs" data-width="360" data-src="/images/history-showa7_2-P1060461-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+        <img class="img-xs" data-width="360" data-src="/images/history-showa7_2-P1060461-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
         <p>↑こちらは、昭和7年頃の明石町の写真です。</p>
-        <div class="img-xs" data-width="360" data-src="/images/history-showa17_1-P1060462-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+        <img class="img-xs" data-width="360" data-src="/images/history-showa17_1-P1060462-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
         <br>
-        <div class="img-xs" data-width="360" data-src="/images/history-showa17_2-P1060465-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+        <img class="img-xs" data-width="360" data-src="/images/history-showa17_2-P1060465-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
         <p>↑こちらは、昭和17年頃の明石町の写真です。</p>
     <h4>4代目　六太郎</h4>
         <p>繁太郎の養子。<br>
             繁太郎の仕事を踏襲し、藍染を中心とした染物と洗い張りといったきもののお手入れや、<ruby><rb>印半纏</rb><rp>(</rp><rt>しるしばんてん</rt><rp>)</rp></ruby>の小売などを行う。<br>
             当時はきものの小売業は行っておらず、お客様が自分できものを縫ったため、仕立ての依頼も無かった。<br>
             丸洗いやしみ抜きもほとんど無く、洗い張りが主流であった。</p>
-        <div class="img-xs" data-width="360" data-src="/images/history-showa37_1-P1060466-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+        <img class="img-xs" data-width="360" data-src="/images/history-showa37_1-P1060466-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
         <br>
-        <div class="img-xs" data-width="360" data-src="/images/history-showa37_2-P1060468-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+        <img class="img-xs" data-width="360" data-src="/images/history-showa37_2-P1060468-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
         <p>↑こちらは、昭和37年頃の明石町の写真です。</p>
-        <div class="img-xs" data-width="360" data-src="/images/history-tokyoolympic1-P1070131-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+        <img class="img-xs" data-width="360" data-src="/images/history-tokyoolympic1-P1070131-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
         <br>
-        <div class="img-xs" data-width="360" data-src="/images/history-tokyoolympic2-P1070135-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+        <img class="img-xs" data-width="360" data-src="/images/history-tokyoolympic2-P1070135-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
         <p>↑こちらは、東京オリンピックの時のだるまやの写真です。</p>
-        <div class="img-xs" data-width="360" data-src="/images/history-heisei12_1-P1060469-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+        <img class="img-xs" data-width="360" data-src="/images/history-heisei12_1-P1060469-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
         <br>
-        <div class="img-xs" data-width="360" data-src="/images/history-heisei12_2-P1060471-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+        <img class="img-xs" data-width="360" data-src="/images/history-heisei12_2-P1060471-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
         <p>↑こちらは、平成12年頃の明石町の写真です。</p>
     <h4>5代目　一夫</h4>
     <p>子供のころから店の仕事を手伝い、高校卒業と同時に店に入る。25歳のときに六太郎から店のすべてを任される。<br>

--- a/information/media.html
+++ b/information/media.html
@@ -12,17 +12,17 @@ order: 40
 
 <section>
     <h2>美しいキモノ2001年秋号</h2>
-    <div class="img-sm" data-width="720" data-src="/images/media-utsukushiikimono1-DSC05218-{width}{pixel_ratio}.JPG" data-alt="美しいキモノ" data-class="img-responsive img-rounded"></div>
-    <div class="img-sm" data-width="720" data-src="/images/media-utsukushiikimono2-DSC05220-{width}{pixel_ratio}.JPG" data-alt="美しいキモノ" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/media-utsukushiikimono1-DSC05218-{width}{pixel_ratio}.JPG" data-alt="美しいキモノ" data-class="img-responsive img-rounded">
+    <img class="img-sm" data-width="720" data-src="/images/media-utsukushiikimono2-DSC05220-{width}{pixel_ratio}.JPG" data-alt="美しいキモノ" data-class="img-responsive img-rounded">
     <h2>手ほどき七緒 2010年11月19日発売</h2>
-    <div class="img-sm" data-width="720" data-src="/images/media-nanao1-DSC05397-{width}{pixel_ratio}.JPG" data-alt="七緒" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/media-nanao1-DSC05397-{width}{pixel_ratio}.JPG" data-alt="七緒" data-class="img-responsive img-rounded">
     <p><a href="http://www.amazon.co.jp/gp/product/4833471191/ref=as_li_ss_tl?ie=UTF8&camp=247&creative=7399&creativeASIN=4833471191&linkCode=as2&tag=yakken-22">DVD付 手ほどき七緒 着物すっきり。「お手入れ」大百科</a><img src="http://ir-jp.amazon-adsystem.com/e/ir?t=yakken-22&l=as2&o=9&a=4833471191" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" />
 
     </p>
     <h2>湘南ジャーナル 2011年1月21日</h2>
-    <div class="img-sm" data-width="720" data-src="/images/media-shonanjournal-DSC05221-{width}{pixel_ratio}.JPG" data-alt="湘南ジャーナル" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/media-shonanjournal-DSC05221-{width}{pixel_ratio}.JPG" data-alt="湘南ジャーナル" data-class="img-responsive img-rounded">
     <h2>七緒 2011年9月発売</h2>
-    <div class="img-sm" data-width="720" data-src="/images/media-nanao2-DSC05396-{width}{pixel_ratio}.JPG" data-alt="七緒" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/media-nanao2-DSC05396-{width}{pixel_ratio}.JPG" data-alt="七緒" data-class="img-responsive img-rounded">
     <p><a href="http://www.amazon.co.jp/gp/product/4833471698/ref=as_li_ss_tl?ie=UTF8&camp=247&creative=7399&creativeASIN=4833471698&linkCode=as2&tag=yakken-22">七緒 vol.27―着物からはじまる暮らし 特集:「お直し」パラダイス/「運命の帯」を探す</a><img src="http://ir-jp.amazon-adsystem.com/e/ir?t=yakken-22&l=as2&o=9&a=4833471698" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" /></p>
     <h2>エコの作法 2011年12月2日放送</h2>
     <p><iframe width="560" height="315" src="//www.youtube.com/embed/ogEJOwNI8a4" frameborder="0" allowfullscreen></iframe><br>
@@ -33,7 +33,7 @@ order: 40
     <iframe src="http://rcm-fe.amazon-adsystem.com/e/cm?lt1=_blank&bc1=000000&IS2=1&bg1=FFFFFF&fc1=000000&lc1=0000FF&t=yakken-22&o=9&p=8&l=as4&m=amazon&f=ifr&ref=ss_til&asins=4047277002" style="width:120px;height:240px;" scrolling="no" marginwidth="0" marginheight="0" frameborder="0"></iframe>
     </p>
     <h2>謎解き！江戸のススメ #34 2012年11月19日放送</h2>
-    <div class="img-sm" data-width="720" data-src="/images/media-edonosusume-screenshot2_2-{width}{pixel_ratio}.JPG" data-alt="美しいキモノ" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/media-edonosusume-screenshot2_2-{width}{pixel_ratio}.JPG" data-alt="美しいキモノ" data-class="img-responsive img-rounded">
     <p><a href = "http://www.bs-tbs.co.jp/edo/backnumber/34.html" target = "_blank">番組のホームページはこちら</a><br>
     <a href = "http://blog.darumaya-gofuku.jp/2012/11/1119.html" target = "_blank">撮影時の様子はこちら</a>
     </p>

--- a/information/newsletter.html
+++ b/information/newsletter.html
@@ -12,7 +12,7 @@ order: 50
 <section>
     <h2>ポストカード</h2>
     <p>感謝祭や展示会など、だるまやの催事の際にポストカードをお送りしています。</p>
-    <div class="img-sm" data-width="720" data-src="/images/newsletter-postcard-DSC05270-{width}{pixel_ratio}.JPG" data-alt="ポストカード" data-class="img-responsive img-rounded"></div><br>
+    <img class="img-sm" data-width="720" data-src="/images/newsletter-postcard-DSC05270-{width}{pixel_ratio}.JPG" data-alt="ポストカード" data-class="img-responsive img-rounded"><br>
     <p>以下のフォームにお名前、内容枠にお客様のご住所とポストカード希望の旨を記入して送信してください。<br>
         なお、メールアドレスもご記入いただくと、メールマガジンも併せて登録いたします。<br>
         ポストカードは店内でもお渡しできますので、遠慮無くお声がけくださいませ。</p>

--- a/information/staff.html
+++ b/information/staff.html
@@ -12,24 +12,24 @@ order: 20
 
 <section>
     <h3>八木一夫(5代目)</h3>
-    <div class="img-sm" data-width="720" data-src="/images/staff-kazuo-DSC04910-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/staff-kazuo-DSC04910-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
     <p>現だるまやの店主。小学校3年生のころからお店の手伝いを始める。<br>
         趣味は神輿とお祭り騒ぎ。</p>
     <br>
     <h3>八木ノブ</h3>
-    <div class="img-sm" data-width="720" data-src="/images/staff-nobu-DSC04642-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/staff-nobu-DSC04642-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
     <p>一夫の母。<br>
         趣味は長唄とお茶。<br>
         <br />
         <a href="http://blog.darumaya-gofuku.jp/search/label/%E3%81%B0%E3%81%82%E3%81%A1%E3%82%83%E3%82%93%E3%81%AE%E7%9D%80%E3%81%93%E3%81%AA%E3%81%97">大人気！ばあちゃんの着こなしはこちら！</a></p>
     <br>
     <h3>八木賢一(6代目)</h3>
-    <div class="img-sm" data-width="720" data-src="/images/staff-kenichi-DSC05083-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/staff-kenichi-DSC05083-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
     <p>大学卒業後、4年間のサラリーマン生活を経て、2008年5月からだるまやの跡継ぎ修行を始める。<br>
         趣味は料理と、美味しいものを食べることお酒を飲むこと。</p>
     <br>
     <h3>清水理恵</h3>
-    <div class="img-sm" data-width="720" data-src="/images/staff-rie-DSC05037-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded"></div>
+    <img class="img-sm" data-width="720" data-src="/images/staff-rie-DSC05037-{width}{pixel_ratio}.JPG" data-alt="乾かす" data-class="img-responsive img-rounded">
     <p>家具や雑貨が好き。<br>
         子どもは上が男の子で下が女の子。（2014年現在、6歳と4歳。）</p>
 </section>

--- a/maintenance/fee.html
+++ b/maintenance/fee.html
@@ -206,7 +206,7 @@ related:
         {% for thumbnail in page.related %}
         <div class="col-xs-6 col-sm-4 col-md-3">
             <a href="{{ thumbnail.link }}" class="thumbnail">
-                <div class="img-xs" data-src="{{ thumbnail.image }}" data-alt="{{ thumbnail.title }}"></div>
+                <img class="img-xs" data-src="{{ thumbnail.image }}" data-alt="{{ thumbnail.title }}">
                 <div class="caption">
                     <h4>{{ thumbnail.title }}</h4>
                     <p>{{ thumbnail.description }}</p>

--- a/maintenance/mon.html
+++ b/maintenance/mon.html
@@ -42,7 +42,7 @@ order: 50
             この中に紋を入れるのですが、染めるわけではなく、黒い染料で描くだけなので、洗うと染料がにじんできてしまうのです。<br>
             このことを紋から色が出るとか、紋が泣く、と言います。<br>
             紋から色が出てしまった場合には、元の紋の上から紋を切り付けるという方法を用います。</p>
-        <div class="img-xs" data-width="360" data-src="/images/mon-monganaku-DSC05149-{width}{pixel_ratio}.JPG" data-alt="事前確認" data-class="img-responsive img-rounded"></div>
+        <img class="img-xs" data-width="360" data-src="/images/mon-monganaku-DSC05149-{width}{pixel_ratio}.JPG" data-alt="事前確認" data-class="img-responsive img-rounded">
     </ul>
 </section>
 <section>

--- a/maintenance/shitate.html
+++ b/maintenance/shitate.html
@@ -108,7 +108,7 @@ related:
         {% for thumbnail in page.related %}
         <div class="col-xs-6 col-sm-4 col-md-3">
             <a href="{{ thumbnail.link }}" class="thumbnail">
-                <div class="img-xs" data-src="{{ thumbnail.image }}" data-alt="{{ thumbnail.title }}"></div>
+                <img class="img-xs" data-src="{{ thumbnail.image }}" data-alt="{{ thumbnail.title }}">
                 <div class="caption">
                     <h4>{{ thumbnail.title }}</h4>
                     <p>{{ thumbnail.description }}</p>

--- a/maintenance/some.html
+++ b/maintenance/some.html
@@ -114,7 +114,7 @@ related:
         {% for thumbnail in page.related %}
         <div class="col-xs-6 col-sm-4 col-md-3">
             <a href="{{ thumbnail.link }}" class="thumbnail">
-                <div class="img-xs" data-src="{{ thumbnail.image }}" data-alt="{{ thumbnail.title }}"></div>
+                <img class="img-xs" data-src="{{ thumbnail.image }}" data-alt="{{ thumbnail.title }}">
                 <div class="caption">
                     <h4>{{ thumbnail.title }}</h4>
                     <p>{{ thumbnail.description }}</p>

--- a/revival/shitatenaoshi.html
+++ b/revival/shitatenaoshi.html
@@ -10,9 +10,9 @@ category: 'きものの再生事例'
 order: 20
 ---
 <section><h2>きものを洗い張りして、寸法・裏地を変えて仕立て直しませんか？</h2>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode1-P1060743-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode1-P1060743-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
     <p>↓</p>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode2-P1070195-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode2-P1070195-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
     <p>せっかくきものをいただいたのに寸法が合わない、お母様の振袖をお嬢様に着せたいけれど裄が短い、などお困りではありませんか？<br>
         胴裏の黄変やしみがひどい場合は、胴裏を新しくすることで、きものが綺麗に生まれ変わります。<br>
         また、合わせて八掛を変えることで、全体のイメージがかなり変わりますよ。</p>
@@ -22,14 +22,14 @@ order: 20
 <section>
     <h2>お母さんの振袖を娘さんの寸法に仕立て直した事例</h2>
     <h3>お手入れ前</h3>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode1-P1060743-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode3-P1060757-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode1-P1060743-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode3-P1060757-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
     <p>お母さんが着た振袖を娘さんの寸法に仕立て直したいとお持ちになりました。<br>
         お母さんと比べて娘さんの身長が10cm以上高く、手も長いためこのままでは到底着られません。<br>
         振袖自体はかなり良い柄で娘さんも気に入っており、なんとか直して着せたいとのご希望でした。</p>
     <h3>お手入れ後</h3>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode4-P1070201-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode2-P1070195-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode4-P1070201-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-furisode2-P1070195-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
     <p>振袖を解いて洗い張りをし、娘さんの寸法に仕立て直しました。<br>
         胴裏も黄色くなっていたため新しくし、伊達衿も付けて仕立てました。<br>
         娘さんにぴったりの寸法になり、とても喜んで成人式に出かけられたそうです。
@@ -44,14 +44,14 @@ order: 20
 <section>
     <h2>仕立直しでしみを隠した事例</h2>
     <h3>お手入れ前</h3>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-shimiwokakusu1-DSC03194-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-shimiwokakusu2-DSC03197-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-shimiwokakusu1-DSC03194-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-shimiwokakusu2-DSC03197-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
     <p>前衽の目立つところにしみができてしまいました。<br>
         このしみを落としたいというご要望だったのですが、かなり古いしみのため、しみ抜きをしても落ちそうもありませんでした。<br>
         寸法もお客様に合っていないということだったので、洗い張りから仕立て直しで、しみを見えないところに隠そうと提案しました。<br>
     <h3>お手入れ後</h3>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-shimiwokakusu3-DSC03918-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-shimiwokakusu4-DSC03921-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-shimiwokakusu3-DSC03918-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-shimiwokakusu4-DSC03921-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
     <p>前衽と下前衽を入れ替えて、身頃を内揚げのところで切り、しみを隠れる位置に入れ替えました。<br>
         この写真では分かりませんが、紋の周りも汚れていたため、左右の身頃も入れ替え、しみを隠しています。<br>
         紋付きにしたいという希望だったので、紋も入れました。<br>
@@ -67,14 +67,14 @@ order: 20
 <section>
     <h2>きものと羽織できもの1枚に仕立てた事例</h2>
     <h3>お手入れ前</h3>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-ASde1mai1-DSC04545-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-ASde1mai2-DSC04544-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-ASde1mai1-DSC04545-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-ASde1mai2-DSC04544-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
     <p>お客様がお持ちになったきものと羽織ですが、全体的に小さいため寸法を直したいというご希望でした。<br>
         寸法を測ってみると、確かに小さく、袖などはかなり短く切ってしまっていたため、きものと羽織に直すことはできませんでした。<br>
         そこで、きものと羽織を洗い張りして、一枚のきものを仕立てましょうという提案をしました。<br>
         羽織の身頃からきものの袖を取り、きものの袖を足し布に使うことにしました。<br>
     <h3>お手入れ後</h3>
-    <div class="img-xs" data-width="360" data-src="/images/shitatenaosu-ASde1mai3-DSC05139-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/shitatenaosu-ASde1mai3-DSC05139-{width}{pixel_ratio}.JPG" data-alt="仕立て直し" data-class="img-responsive img-rounded">
     <p>お客様のご希望の寸法通りのきものが一枚仕上がりました。<br>
         お客様も半ばあきらめていたようですが、生まれ変わったきものを見て大変喜んでいただけました。<br>
     </p>

--- a/revival/somenaoshi.html
+++ b/revival/somenaoshi.html
@@ -18,14 +18,14 @@ order: 40
 <section>
     <h2>無地のきものを染め直した事例</h2>
     <h3>お手入れ前</h3>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-mujipink1-P1050759-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-mujipink2-P1050757-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-mujipink1-P1050759-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-mujipink2-P1050757-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>お嫁に行く時にお母さんが持たせてくれた無地のきものを着ようと思ったものの、このピンク色じゃ着れないので染め直したいとお持ちになりました。<br>
         寸法も合わなくなってしまったので、寸法も今の体型に合わせて仕立て直したいとのこと。<br>
         今までは紋なしで仕立ててありましたが、今後着る機会を考えると紋も入れておこうということになりました。</p>
     <h3>お手入れ後</h3>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-mujigreen1-P1060581-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-mujigreen2-P1060582-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-mujigreen1-P1060581-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-mujigreen2-P1060582-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>お客様がお選びになったのが若草色。<br>
         元のピンク色からだいぶ落ち着き、この色なら今でも十分着られるとのことでした。<br>
         また、色を選ぶ時にお持ちの帯もお持ちいただき、その帯に合う色を一緒に考えて決めました。</p>
@@ -41,13 +41,13 @@ order: 40
 <section>
     <h2>附下訪問着に色をかけて地味にした事例</h2>
     <h3>お手入れ前</h3>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-mehiki1-P1050752-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-mehiki2-P1050755-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-mehiki1-P1050752-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-mehiki2-P1050755-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>お若いころに誂えた附下が派手で着られないのでなんとかならないかというご相談でした。<br>
         解いて上から色を掛けることで全体的に地味にしましょうという提案をしました。<br>
     <h3>お手入れ後</h3>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-mehiki3-P1060560-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-mehiki4-P1060562-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-mehiki3-P1060560-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-mehiki4-P1060562-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>地色は芥子色にしました。<br>
         上から色を掛けると地色と柄の差が縮まり、全体的に地味になります。<br>
         お客様もこれなら十分着られるとおっしゃっていられました。<br>
@@ -65,16 +65,16 @@ order: 40
 <section>
     <h2>訪問着の柄を活かして染め直した事例</h2>
     <h3>お手入れ前</h3>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi1-DSC04227-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi2-DSC04229-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi3-DSC04230-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi1-DSC04227-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi2-DSC04229-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi3-DSC04230-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>お客様がお持ちになったきものの地色が少し派手でこのままでは着られないとのことでした。<br>
         上から色をかけてしまうと柄が死んでしまうので、柄をのりで伏せて、地色だけ刷毛で染めましょうという提案をしました。<br>
         実家の紋が入っていたため、紋も入れ直し、寸法も今のお客様に合わせて仕立て直しました。</p>>
     <h3>お手入れ後</h3>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi4-DSC04557-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi5-DSC04565-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi6-DSC04562-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi4-DSC04557-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi5-DSC04565-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/somenaoshi-garaikashi6-DSC04562-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>地色は濃い目の紺にしました。<br>
         きものの印象がガラッと変わり、元のきものの色よりむしろこっちのほうが良いというほど良くなりました。<br>
         元々あったしみもほとんど目立たなくなり、お客様も大変喜ばれ、ご親戚の結婚式に着て行かれたそうです。<br>

--- a/revival/tocoat.html
+++ b/revival/tocoat.html
@@ -19,16 +19,16 @@ order: 80
 <section>
     <h2>きものを染め直して道行コートに仕立て直した事例</h2>
     <h3>お手入れ前</h3>
-    <div class="img-xs" data-width="360" data-src="/images/tocoat-someandcoat1-P1060679-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/tocoat-someandcoat2-P1060685-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/tocoat-someandcoat1-P1060679-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/tocoat-someandcoat2-P1060685-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>手持ちの無地のきものを道行コートに仕立て直したいと言ってお持ちになりました。<br>
         生地の巾も丈も問題なかったのですが、色が少しコートに向かなかったので、染め直してコートにしましょうとご提案しました。
     </p>
-    <div class="img-xs" data-width="360" data-src="/images/tocoat-someandcoat3-P1060957-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/tocoat-someandcoat3-P1060957-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>お持ちのきものに合わせやすい色を選んでいただき、その色にあったコート裏を選んでいただきました。</p>
     <h3>お手入れ後</h3>
-    <div class="img-xs" data-width="360" data-src="/images/tocoat-someandcoat4-P1070151-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/tocoat-someandcoat5-P1070157-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/tocoat-someandcoat4-P1070151-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/tocoat-someandcoat5-P1070157-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>生まれ変わったコートを見て大変満足していただけました。</p>
     <h3>きものを染め直して道行コートに仕立て直す料金</h3>
     <p>解いて染め直す：10,000円<br>

--- a/revival/tohikifurisode.html
+++ b/revival/tohikifurisode.html
@@ -18,13 +18,13 @@ order: 140
         その後、娘さんのご結婚が決まり、花嫁衣装として引き振袖を着たいと思った時に、お母さんの振袖を直せないか？と思い、ご相談いただきました。
     </p>
     <h3>お手入れ中</h3>
-    <div class="img-xs" data-width="360" data-src="/images/hikifurisode-shiroji1-DSC04668-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/hikifurisode-shiroji2-DSC04686-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/hikifurisode-shiroji1-DSC04668-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/hikifurisode-shiroji2-DSC04686-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>寸法が難しいため、一度仮縫い状態で丈の加減を見てみます。<br>
        また、裏地を縫った段階で一度お客様にもご来店いただき、丈などを確認していただきました。</p>
     <h3>お手入れ後</h3>
-    <div class="img-xs" data-width="360" data-src="/images/hikifurisode-shiroji3-DSC04759-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/hikifurisode-shiroji4-DSC04975-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/hikifurisode-shiroji3-DSC04759-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/hikifurisode-shiroji4-DSC04975-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>仕上がった引き振袖を見てとても喜んでいただけました。<br>
        この時は比翼や伊達衿の色も白から染めて仕立てたので、とても華やかな引き振袖になりました。</p>
     <h3>振袖を引き振袖に仕立て直す料金</h3>

--- a/revival/toobi.html
+++ b/revival/toobi.html
@@ -18,18 +18,18 @@ order: 120
 <section>
     <h2>丈の短い羽織をなごや帯に仕立て直した事例</h2>
     <h3>お手入れ前</h3>
-    <div class="img-xs" data-width="360" data-src="/images/toobi-shirohaori1-P1060632-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/toobi-shirohaori2-P1060639-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/toobi-shirohaori1-P1060632-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/toobi-shirohaori2-P1060639-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>ご家族からもらった羽織。柄は気に入ったものの丈が短くて着られないとのご相談でした。<br>
         あいにくこれ以上長くすることはできなかったので、思い切って帯に仕立て直してみたらどうですか？と提案しました。
     </p>
     <h3>お手入れ後</h3>
-    <div class="img-xs" data-width="360" data-src="/images/toobi-shirohaori3-P1060710-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/toobi-shirohaori4-P1060875-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/toobi-shirohaori3-P1060710-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/toobi-shirohaori4-P1060875-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>一度解いて洗い張りをしてなごや帯に仕立て直しました。<br>
         生まれ変わった帯を見てお客様もとてもびっくりしていました。</p>
-    <div class="img-xs" data-width="360" data-src="/images/toobi-shirohaori5-P1080635-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
-    <div class="img-xs" data-width="360" data-src="/images/toobi-shirohaori6-P1080636-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded"></div>
+    <img class="img-xs" data-width="360" data-src="/images/toobi-shirohaori5-P1080635-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
+    <img class="img-xs" data-width="360" data-src="/images/toobi-shirohaori6-P1080636-{width}{pixel_ratio}.JPG" data-alt="歴史" data-class="img-responsive img-rounded">
     <p>後日改めてその帯を締めてご来店いただきました。<br>
         きもの仲間にもとても褒められたそうで、とても喜んでいただけました。</p>
     <h3>きものや羽織をなごや帯に仕立て直す料金</h3>

--- a/template/images.html
+++ b/template/images.html
@@ -8,7 +8,7 @@ layout: default
     <p>画像は<code>&lt;div&gt;</code>タグで記述します。自動的に<code>&lt;img&gt;</code>タグに書き換えられます。</p>
 
     <h3>Extra Small サイズ</h3>
-    {% capture html %}<div class="img-xs" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>{% endcapture %}
+    {% capture html %}<img class="img-xs" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">{% endcapture %}
 <pre>
 {{ html | escape }}
 </pre>
@@ -17,7 +17,7 @@ layout: default
     </p>
 
     <h3>Small サイズ</h3>
-    {% capture html %}<div class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>{% endcapture %}
+    {% capture html %}<img class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">{% endcapture %}
 <pre>
 {{ html | escape }}
 </pre>
@@ -27,7 +27,7 @@ layout: default
 
     <h3>Medium サイズ</h3>
 
-    {% capture html %}<div class="img-md" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>{% endcapture %}
+    {% capture html %}<img class="img-md" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">{% endcapture %}
 <pre>
 {{ html | escape }}
 </pre>
@@ -36,7 +36,7 @@ layout: default
     </p>
 
     <h3>Large サイズ</h3>
-    {% capture html %}<div class="img-lg" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>{% endcapture %}
+    {% capture html %}<img class="img-lg" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">{% endcapture %}
 <pre>
 {{ html | escape }}
 </pre>
@@ -45,7 +45,7 @@ layout: default
     </p>
 
     <h3>data-width指定</h3>
-    {% capture html %}<div class="img-xs" data-width="100" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>{% endcapture %}
+    {% capture html %}<img class="img-xs" data-width="100" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">{% endcapture %}
 <pre>
 {{ html | escape }}
 </pre>
@@ -54,7 +54,7 @@ layout: default
     </p>
 
     <h3>pixel rationのみに利用</h3>
-    {% capture html %}<div class="img-xs" data-width="100" data-src="/images/dummy-xs{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>{% endcapture %}
+    {% capture html %}<img class="img-xs" data-width="100" data-src="/images/dummy-xs{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">{% endcapture %}
 <pre>
 {{ html | escape }}
 </pre>
@@ -65,46 +65,46 @@ layout: default
     <h3>4カラム</h3>
     <div class="row">
         <div class="col-sm-3">
-            <div class="img-xs" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>
+            <img class="img-xs" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">
         </div>
         <div class="col-sm-3">
-            <div class="img-xs" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>
+            <img class="img-xs" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">
         </div>
         <div class="col-sm-3">
-            <div class="img-xs" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>
+            <img class="img-xs" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">
         </div>
         <div class="col-sm-3">
-            <div class="img-xs" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>
+            <img class="img-xs" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">
         </div>
     </div>
 
     <h3>3カラム</h3>
     <div class="row">
         <div class="col-sm-4">
-            <div class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>
+            <img class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">
         </div>
         <div class="col-sm-4">
-            <div class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>
+            <img class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">
         </div>
         <div class="col-sm-4">
-            <div class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>
+            <img class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">
         </div>
     </div>
 
     <h3>2カラム</h3>
     <div class="row">
         <div class="col-sm-6">
-            <div class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>
+            <img class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">
         </div>
         <div class="col-sm-6">
-            <div class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>
+            <img class="img-sm" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">
         </div>
     </div>
 
     <h3>1カラム</h3>
     <div class="row">
         <div class="col-sm-12">
-            <div class="img-lg" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded"></div>
+            <img class="img-lg" data-src="/images/dummy-{width}{pixel_ratio}.png" data-alt="dummy" data-class="img-responsive img-rounded">
         </div>
     </div>
 </div>


### PR DESCRIPTION
レスポンシブ画像に`<div></div>`を使った場合、`<a><div></div></a>`というタグが、ブラウザに不正と見なされ、`<a></a><div></div>`に変換されたあと、Imager.jsによって`<a></a><img>`に置き換えられるので、画像にリンクを貼ることができなくなってしまう。
`<div></div>`ではなく`<img>`を使うことによって解決した。
